### PR TITLE
adding max-memory and entrypoint environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and your node app will run.
 
 ## How does it work?
 
-You'll need a ```server.js``` file to be the entrypoint of your app by default.  (To make jarnode point elsewhere, set a ```NODE_ENTRY_FILENAME``` environment variable)
+Jarnode uses the ```main``` property in your ```package.json``` file to get the entrypoint to your app.  If this isn't set, it will use ```server.js``` by default.
 
 You also need this POM as pom.xml in your nodejs project:
 
@@ -226,9 +226,15 @@ deleting the directory first.
 
 ## I want to specify the max memory limit for my node app
 
-Set a ```NODE_MEMORY_LIMIT``` environment variable stating the limit in **Megabytes** - e.g.  ```NODE_MEMORY_LIMIT=64```
+Add the following to your ```package.json```, setting the limit in **megabytes**: (e.g. below is 1024MB)
 
-If this environment variable isn't present then max memory allocation is set at 512MB, as per node defaults.
+```
+"jarnode": {
+    "memoryLimit": "1024"
+}
+```
+
+The max memory allocation is otherwise set at 512MB, as per node defaults.
 
 ## I lost state I stored in the nodeapp when I restarted!
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ and your node app will run.
 
 ## How does it work?
 
-You need this POM as pom.xml in your nodejs project:
+You'll need a ```server.js``` file to be the entrypoint of your app by default.  (To make jarnode point elsewhere, set a ```NODE_ENTRY_FILENAME``` environment variable)
+
+You also need this POM as pom.xml in your nodejs project:
 
 ```xml
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -44,7 +46,7 @@ You need this POM as pom.xml in your nodejs project:
       <version>1.0.16</version>
     </dependency>
   </dependencies>
-  
+
   <build>
     <resources>
       <resource>
@@ -222,9 +224,15 @@ the node app will exist under there.
 If you run the app again it will unpack to the same directory,
 deleting the directory first.
 
+## I want to specify the max memory limit for my node app
+
+Set a ```NODE_MEMORY_LIMIT``` environment variable stating the limit in **Megabytes** - e.g.  ```NODE_MEMORY_LIMIT=64```
+
+If this environment variable isn't present then max memory allocation is set at 512MB, as per node defaults.
+
 ## I lost state I stored in the nodeapp when I restarted!
 
-Yes. Because when you restart we delete the directory. 
+Yes. Because when you restart we delete the directory.
 
 Make a containining directory and store the state there?
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
       <version>2.5</version>
     </dependency>
     <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>3.8.1</version>

--- a/src/main/java/uk/me/ferrier/nic/jarnode/App.java
+++ b/src/main/java/uk/me/ferrier/nic/jarnode/App.java
@@ -64,7 +64,6 @@ public class App
                         Files.delete(file);
                         return FileVisitResult.CONTINUE;
                     }
-                    
                     @Override
                     public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
                         Files.delete(dir);
@@ -139,6 +138,20 @@ public class App
         }
     }
 
+    static String getNodeEntryPointFilename() {
+        String defaultFilename = "server.js";
+        String customFilename = System.getenv("NODE_ENTRY_FILENAME");
+        String fileName = (customFilename != null && !customFilename.isEmpty()) ? customFilename : defaultFilename;
+        return fileName;
+    }
+
+    static String getNodeMemoryLimitArg() {
+        String defaultLimit = "512"; // 512MB is node default
+        String customLimit = System.getenv("NODE_MEMORY_LIMIT");
+        String memLimit = (customLimit != null && !customLimit.isEmpty()) ? customLimit : defaultLimit;
+        return "--max-old-space-size=" + memLimit;
+    }
+
     /*
 
       support python
@@ -153,8 +166,8 @@ python t.py
 mkdir demojarplace
 cp demoapp/demo.jar demojarplace
 cd demojarplace
-jar xvf demo.jar 
-cp ~/script . 
+jar xvf demo.jar
+cp ~/script .
 bash script
 
      */
@@ -193,7 +206,7 @@ bash script
         }
         String nodeExe = nodePath.get(0).name + "/node";
         nodeExe = isWin? nodeExe + ".exe" : nodeExe;
-        ProcessBuilder builder = new ProcessBuilder(nodeExe, "server.js");
+        ProcessBuilder builder = new ProcessBuilder(nodeExe, getNodeEntryPointFilename(), getNodeMemoryLimitArg());
         builder.directory(nodeAppJarDir);
         builder.redirectErrorStream(true);
         final Process p = builder.start();

--- a/src/test/java/uk/me/ferrier/nic/jarnode/AppTest.java
+++ b/src/test/java/uk/me/ferrier/nic/jarnode/AppTest.java
@@ -125,13 +125,13 @@ public class AppTest
         assertTrue( result1.equals("--max-old-space-size=512") );
 
         // when there is jarnode config with no memoryLimit set
-        JSONObject fakePackageJson = new JSONObject();
-        String result2 = App.getNodeMemoryLimitArg(fakePackageJson);
+        JSONObject fakeJarnodeConfig = new JSONObject();
+        String result2 = App.getNodeMemoryLimitArg(fakeJarnodeConfig);
         assertTrue( result2.equals("--max-old-space-size=512") );
 
         // when there is jarnode config with memoryLimit set
-        fakePackageJson.put("memoryLimit", "64");
-        String result3 = App.getNodeMemoryLimitArg(fakePackageJson);
+        fakeJarnodeConfig.put("memoryLimit", "64");
+        String result3 = App.getNodeMemoryLimitArg(fakeJarnodeConfig);
         assertTrue( result3.equals("--max-old-space-size=64") );
     }
 }

--- a/src/test/java/uk/me/ferrier/nic/jarnode/AppTest.java
+++ b/src/test/java/uk/me/ferrier/nic/jarnode/AppTest.java
@@ -90,4 +90,14 @@ public class AppTest
         boolean confFileExists = confFilePath.exists();
         assertTrue( confFileExists );
     }
+
+    public void testNodeEntryPointFilename() throws Exception {
+        String arg = App.getNodeEntryPointFilename();
+        assertTrue( arg.equals("server.js") );
+    }
+
+    public void testNodeMemoryLimitArgument() throws Exception {
+        String arg = App.getNodeMemoryLimitArg();
+        assertTrue( arg.equals("--max-old-space-size=512") );
+    }
 }


### PR DESCRIPTION
The entrypoint that jarnode looks for is currently hardcoded to ```server.js```.  Adding option to change by defining a ```NODE_ENTRY_FILENAME``` env var.

Adding option to set a memory limit via defining a ```NODE_MEMORY_LIMIT``` env var.